### PR TITLE
Node needed 'use strict' statement

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -1,20 +1,20 @@
-'use strict';
+'use strict'
 // @flow
 /**
  * A module for converting cryptographic keys into human-readable phrases.
  * @module niceware
  */
 
-const bs = require('binary-search');
-const wordlist = require('./wordlist');
-const randomBytes = require('randombytes');
+const bs = require('binary-search')
+const wordlist = require('./wordlist')
+const randomBytes = require('randombytes')
 
-const MAX_PASSPHRASE_SIZE = 1024; // Max size of passphrase in bytes
+const MAX_PASSPHRASE_SIZE = 1024 // Max size of passphrase in bytes
 
 /**
  * @alias module:niceware
  */
-const niceware = {};
+const niceware = {}
 
 /**
  * Converts a byte array into a passphrase.
@@ -26,28 +26,28 @@ niceware.bytesToPassphrase = function (bytes) {
   // context.
   if (!Buffer.isBuffer(bytes) &&
     !(typeof window === 'object' && bytes instanceof window.Uint8Array)) {
-    throw new Error('Input must be a Buffer or Uint8Array.');
+    throw new Error('Input must be a Buffer or Uint8Array.')
   }
   if (bytes.length % 2 === 1) {
-    throw new Error('Only even-sized byte arrays are supported.');
+    throw new Error('Only even-sized byte arrays are supported.')
   }
-  const words = [];
+  const words = []
   for (var entry of bytes.entries()) {
-    let index = entry[0];
-    let byte = entry[1];
-    let next = bytes[index + 1];
+    let index = entry[0]
+    let byte = entry[1]
+    let next = bytes[index + 1]
     if (index % 2 === 0) {
-      let wordIndex = byte * 256 + next;
-      let word = wordlist[wordIndex];
+      let wordIndex = byte * 256 + next
+      let word = wordlist[wordIndex]
       if (!word) {
-        throw new Error('Invalid byte encountered');
+        throw new Error('Invalid byte encountered')
       } else {
-        words.push(word);
+        words.push(word)
       }
     }
   }
-  return words;
-};
+  return words
+}
 
 /**
  * Converts a phrase back into the original byte array.
@@ -56,30 +56,30 @@ niceware.bytesToPassphrase = function (bytes) {
  */
 niceware.passphraseToBytes = function (words/* : Array<string> */) {
   if (!Array.isArray(words)) {
-    throw new Error('Input must be an array.');
+    throw new Error('Input must be an array.')
   }
 
-  const bytes = Buffer.alloc(words.length * 2);
+  const bytes = Buffer.alloc(words.length * 2)
 
   words.forEach((word, index) => {
     if (typeof word !== 'string') {
-      throw new Error('Word must be a string.');
+      throw new Error('Word must be a string.')
     }
     const wordIndex = bs(wordlist, word.toLowerCase(), (a, b) => {
       if (a === b) {
-        return 0;
+        return 0
       }
-      return a > b ? 1 : -1;
-    });
+      return a > b ? 1 : -1
+    })
     if (wordIndex < 0) {
-      throw new Error('Invalid word: ' + word);
+      throw new Error('Invalid word: ' + word)
     }
-    bytes[2 * index] = Math.floor(wordIndex / 256);
-    bytes[2 * index + 1] = wordIndex % 256;
-  });
+    bytes[2 * index] = Math.floor(wordIndex / 256)
+    bytes[2 * index + 1] = wordIndex % 256
+  })
 
-  return bytes;
-};
+  return bytes
+}
 
 /**
  * Generates a random passphrase with the specified number of bytes.
@@ -89,15 +89,15 @@ niceware.passphraseToBytes = function (words/* : Array<string> */) {
  */
 niceware.generatePassphrase = function (size/* : number */) {
   if (typeof size !== 'number' || size < 0 || size > MAX_PASSPHRASE_SIZE) {
-    throw new Error('Size must be between 0 and 1024 bytes.');
+    throw new Error('Size must be between 0 and 1024 bytes.')
   }
-  const bytes = randomBytes(size);
-  return niceware.bytesToPassphrase(bytes);
-};
+  const bytes = randomBytes(size)
+  return niceware.bytesToPassphrase(bytes)
+}
 
 // For browserify
 if (typeof window === 'object') {
-  window.niceware = niceware;
+  window.niceware = niceware
 }
 
-module.exports = niceware;
+module.exports = niceware

--- a/lib/main.js
+++ b/lib/main.js
@@ -1,19 +1,20 @@
+'use strict';
 // @flow
 /**
  * A module for converting cryptographic keys into human-readable phrases.
  * @module niceware
  */
 
-const bs = require('binary-search')
-const wordlist = require('./wordlist')
-const randomBytes = require('randombytes')
+const bs = require('binary-search');
+const wordlist = require('./wordlist');
+const randomBytes = require('randombytes');
 
-const MAX_PASSPHRASE_SIZE = 1024 // Max size of passphrase in bytes
+const MAX_PASSPHRASE_SIZE = 1024; // Max size of passphrase in bytes
 
 /**
  * @alias module:niceware
  */
-const niceware = {}
+const niceware = {};
 
 /**
  * Converts a byte array into a passphrase.
@@ -25,28 +26,28 @@ niceware.bytesToPassphrase = function (bytes) {
   // context.
   if (!Buffer.isBuffer(bytes) &&
     !(typeof window === 'object' && bytes instanceof window.Uint8Array)) {
-    throw new Error('Input must be a Buffer or Uint8Array.')
+    throw new Error('Input must be a Buffer or Uint8Array.');
   }
   if (bytes.length % 2 === 1) {
-    throw new Error('Only even-sized byte arrays are supported.')
+    throw new Error('Only even-sized byte arrays are supported.');
   }
-  const words = []
+  const words = [];
   for (var entry of bytes.entries()) {
-    let index = entry[0]
-    let byte = entry[1]
-    let next = bytes[index + 1]
+    let index = entry[0];
+    let byte = entry[1];
+    let next = bytes[index + 1];
     if (index % 2 === 0) {
-      let wordIndex = byte * 256 + next
-      let word = wordlist[wordIndex]
+      let wordIndex = byte * 256 + next;
+      let word = wordlist[wordIndex];
       if (!word) {
-        throw new Error('Invalid byte encountered')
+        throw new Error('Invalid byte encountered');
       } else {
-        words.push(word)
+        words.push(word);
       }
     }
   }
-  return words
-}
+  return words;
+};
 
 /**
  * Converts a phrase back into the original byte array.
@@ -55,30 +56,30 @@ niceware.bytesToPassphrase = function (bytes) {
  */
 niceware.passphraseToBytes = function (words/* : Array<string> */) {
   if (!Array.isArray(words)) {
-    throw new Error('Input must be an array.')
+    throw new Error('Input must be an array.');
   }
 
-  const bytes = Buffer.alloc(words.length * 2)
+  const bytes = Buffer.alloc(words.length * 2);
 
   words.forEach((word, index) => {
     if (typeof word !== 'string') {
-      throw new Error('Word must be a string.')
+      throw new Error('Word must be a string.');
     }
     const wordIndex = bs(wordlist, word.toLowerCase(), (a, b) => {
       if (a === b) {
-        return 0
+        return 0;
       }
-      return a > b ? 1 : -1
-    })
+      return a > b ? 1 : -1;
+    });
     if (wordIndex < 0) {
-      throw new Error(`Invalid word: ${word}`)
+      throw new Error('Invalid word: ' + word);
     }
-    bytes[2 * index] = Math.floor(wordIndex / 256)
-    bytes[2 * index + 1] = wordIndex % 256
-  })
+    bytes[2 * index] = Math.floor(wordIndex / 256);
+    bytes[2 * index + 1] = wordIndex % 256;
+  });
 
-  return bytes
-}
+  return bytes;
+};
 
 /**
  * Generates a random passphrase with the specified number of bytes.
@@ -88,15 +89,15 @@ niceware.passphraseToBytes = function (words/* : Array<string> */) {
  */
 niceware.generatePassphrase = function (size/* : number */) {
   if (typeof size !== 'number' || size < 0 || size > MAX_PASSPHRASE_SIZE) {
-    throw new Error(`Size must be between 0 and ${MAX_PASSPHRASE_SIZE} bytes.`)
+    throw new Error('Size must be between 0 and 1024 bytes.');
   }
-  const bytes = randomBytes(size)
-  return niceware.bytesToPassphrase(bytes)
-}
+  const bytes = randomBytes(size);
+  return niceware.bytesToPassphrase(bytes);
+};
 
 // For browserify
 if (typeof window === 'object') {
-  window.niceware = niceware
+  window.niceware = niceware;
 }
 
-module.exports = niceware
+module.exports = niceware;

--- a/lib/main.js
+++ b/lib/main.js
@@ -72,7 +72,7 @@ niceware.passphraseToBytes = function (words/* : Array<string> */) {
       return a > b ? 1 : -1
     })
     if (wordIndex < 0) {
-      throw new Error('Invalid word: ' + word)
+      throw new Error(`Invalid word: ${word}`)
     }
     bytes[2 * index] = Math.floor(wordIndex / 256)
     bytes[2 * index + 1] = wordIndex % 256
@@ -89,7 +89,7 @@ niceware.passphraseToBytes = function (words/* : Array<string> */) {
  */
 niceware.generatePassphrase = function (size/* : number */) {
   if (typeof size !== 'number' || size < 0 || size > MAX_PASSPHRASE_SIZE) {
-    throw new Error('Size must be between 0 and 1024 bytes.')
+    throw new Error(`Size must be between 0 and ${MAX_PASSPHRASE_SIZE} bytes.`)
   }
   const bytes = randomBytes(size)
   return niceware.bytesToPassphrase(bytes)


### PR DESCRIPTION
Thanks for this library - works great, very useful! 

In order to make it work in Node (v4.2.4) I had to add a 'use strict' statement to the top of lib/main.js, otherwise I was getting this error message when I tried to require it: "SyntaxError: Block-scoped declarations (let, const, function, class) not yet supported outside strict mode".

While I was at it, I added semicolons to the line endings so JSHINT would stop complaining.