### PR TITLE
Move default entropy to 80-bits from 64-bits

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,8 +28,8 @@
             <option value='2'>16 bits</option>
             <option value='4'>32 bits</option>
             <option value='6'>48 bits</option>
-            <option value='8' selected>64 bits</option>
-            <option value='10'>80 bits</option>
+            <option value='8'>64 bits</option>
+            <option value='10' selected>80 bits</option>
             <option value='12'>96 bits</option>
             <option value='14'>112 bits</option>
             <option value='16'>128 bits</option>


### PR DESCRIPTION
Given the following scenarious, at least 72-bits should be the target for passphrases these days:

[Bitcoin mining @ 8,000,000 THps](https://blockchain.info/charts/hash-rate):
* 62-bits per second
* 68-bits per minute
* 74-bits per hour
* 79-bits per day
* 87-bits per year

Time to 64-bits: 4 seconds. Time to 80-bits: 2 days

[Distributed.net RC5-72 brute force @ 1,000,000 MKps](https://stats.distributed.net/keyrate.php?project_id=8):
* 39-bits per second
* 45-bits per minute
* 51-bits per hour
* 56-bits per day
* 64-bits per year

Time to 64-bits: 1 year. Time to 80-bits: 65k years

[Professional password cracking @ 180,000 MHps](https://cynosureprime.blogspot.com/2017/08/320-million-hashes-exposed.html):
* 37-bits per second
* 43-bits per minute
* 49-bits per hour
* 53-bits per day
* 62-bits per year

Of course, it's only necessary to exhaust 1/2 of the keyspace to get 50% probability or better that the password is found. Thus:

* 2 seconds to 63-bits with Bitcoin mining
* 6 months to 63-bits with distributed.net
* 2 years to 63-bits with ~ 25 NVidia GPUs