### PR TITLE
Add SRI and simple mobile interface

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,5 +1,9 @@
 <html>
-    <title>Niceware</title>
+    <head>
+        <meta charset="utf8"/>
+        <meta name="viewport" content="width=device-width"/>
+        <title>Niceware</title>
+    </head>
     <body>
     <a href="https://github.com/diracdeltas/niceware"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://camo.githubusercontent.com/38ef81f8aca64bb9a64448d0d70f1308ef5341ab/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f6461726b626c75655f3132313632312e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png"></a>
 <div style='width: 75%; margin: auto; margin-top: 100px; font-size: 20px;'>
@@ -55,7 +59,7 @@
 </div>
 </div>
 
-        <script src='browser/niceware.js'></script>
+        <script src='browser/niceware.js' integrity="sha256-BaL8yaSJUP9H3zCe3OrThXuoOvHNXOt/cly1RtBdZ6o=" crossorigin="anonymous"></script>
         <script>
           function generatePassphrase () {
             var e = document.querySelector('select')


### PR DESCRIPTION
Adding a simple mobile interface via a `<meta>` tag, but additional CSS changes will be needed to tidy things up. This at least makes the site usable on devices without pinch-zooming. Also, adding SHA-256 subresource integrity to the niceware.js reference for anyone who might install this on CDNs. See https://www.w3.org/TR/SRI/.