### PR TITLE
Replaced broken link with wayback machine equivalent

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,6 @@ NOTE: `size` must be an even number.
 
 Niceware was inspired by
 [Diceware](http://world.std.com/~reinhold/diceware.html). Its wordlist is
-derived from http://www-01.sil.org/linguistics/wordlists/english/. This project
+derived from [the SIL English word list](https://web.archive.org/web/20180803153208/http://www-01.sil.org/linguistics/wordlists/english/). This project
 is based on my work on OpenPGP key backup for the Yahoo
 [End-to-End](https://github.com/yahoo/end-to-end) project.


### PR DESCRIPTION
While "live" links are always nice, unfortunately this one has died. There's no point in forcing our reader to find their own archived version when the wayback machine is pretty much the best they'll get (although I'm happy to be proven wrong!).