### PR TITLE
Update README.md to add grempe/niceware-ts TypeScript port

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ NOTE: `size` must be an even number.
 * Chrome extension, thanks to Noah Feder: https://chrome.google.com/webstore/detail/niceware-password/dhnichgmciickpnnnhfcljljnfomadag
 * pip package, thanks to Alex Willmer: https://pypi.python.org/pypi/niceware
 * CLI, thanks to Alex Cross: https://www.npmjs.com/package/nicepass
+* TypeScript package that exports ESM/CommonJS modules, supports Deno, and improves DX: https://github.com/grempe/niceware-ts
 
 ## Credits
 


### PR DESCRIPTION
Hi, I've forked `Niceware` to `Niceware TS` to port it to TypeScript and add a number of modernizations that make it type safe and improve the developer experience. It no longer has dependencies on Node API's. It remains fully compatible and now has a modern test suite that has 100% code coverage (including the wordlist) and benchmark tests. It now exports CommonJS and ESM modules so it can easily be used in modern tooling including Deno.

See the README here: https://github.com/grempe/niceware-ts